### PR TITLE
Possible way of linking from juliawebstack.org to here

### DIFF
--- a/docs/Morsel.md
+++ b/docs/Morsel.md
@@ -1,4 +1,4 @@
-# Morsel
+# [Morsel](https://github.com/hackerschool/Morsel.jl)
 
 Morsel is a Sintra-like micro framework for declaring routes and handling requests.
 It is built on top of HttpServer.jl and Meddle.jl.


### PR DESCRIPTION
I thought this might be a good way to link from juliawebstack.org back to the main repo since there's no direct link on juliawebstack.org.

Thoughts? This would have to be done for each sub-repo, but I wanted to use this as discussion to figure out how to link from juliawebstack.org back to the github repo.
