### PR TITLE
fix an example in spec.jl and add more examples

### DIFF
--- a/spec.jl
+++ b/spec.jl
@@ -72,7 +72,7 @@ namespace(app, "/admin") do abc
         # ...
     end
 end
-# will generate: "/admin-pagse""
+# will generate: "/admin-pages""
 
 route(app, "/*") do req, res
     res.headers["Status"] = 404


### PR DESCRIPTION
Hi!
I try to use "namespace" as the example given in "spec.jl", but I failed. I think it should have a parameter https://github.com/yfractal/Morsel.jl/blob/master/spec.jl#L51.
And i added more examples.

Thanks your package :)
